### PR TITLE
Adding pet_mode to set "indoor only" and "outdoor" to pets, fixes for duplicate feeders.

### DIFF
--- a/custom_components/sureha/__init__.py
+++ b/custom_components/sureha/__init__.py
@@ -31,16 +31,18 @@ from .const import (
     DOMAIN,
     SERVICE_PET_LOCATION,
     SERVICE_SET_LOCK_STATE,
-    SPC,
     SURE_API_TIMEOUT,
     SURE_BATT_VOLTAGE_FULL,
     SURE_BATT_VOLTAGE_LOW,
+    SERVICE_SET_INDOOR_PET_MODE,
+    SERVICE_SET_OUTDOOR_PET_MODE,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER, Platform.SENSOR]
-SCAN_INTERVAL = timedelta(minutes=3)
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.SWITCH]
+# Harmonize SCAN_INTERVAL comment with coordinator's update_interval
+SCAN_INTERVAL = timedelta(seconds=150)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -60,14 +62,14 @@ CATS = [
     "/ᐠ｡▿｡ᐟ\\*ᵖᵘʳʳ",
     "/ᐠ_ꞈ_ᐟ\\ɴʏᴀ~",
     "/ᐠ ._. ᐟ\\ﾉ",
-    "/ᐠ. ｡.ᐟ\\ᵐᵉᵒʷˎˊ",
+    "/\x1b[38;2;255;26;102m·\x1b[0m. ｡.ᐟ\\ᵐᵉᵒʷˎˊ",
     "ᶠᵉᵉᵈ ᵐᵉ /ᐠ-ⱉ-ᐟ\\ﾉ",
     "(≗ᆽ ≗)ﾉ",
 ]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up."""
+    """Set up Surepetcare from a config entry."""
 
     hass.data.setdefault(DOMAIN, {})
 
@@ -85,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         surepy = Surepy(
             entry.data[CONF_USERNAME],
             entry.data[CONF_PASSWORD],
-            auth_token=entry.data[CONF_TOKEN] if CONF_TOKEN in entry.data else None,
+            auth_token=entry.data.get(CONF_TOKEN),
             api_timeout=SURE_API_TIMEOUT,
             session=async_get_clientsession(hass),
         )
@@ -93,7 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error(
             "🐾 \x1b[38;2;255;26;102m·\x1b[0m unable to auth. to surepetcare.io: wrong credentials"
         )
-        return False
+        raise ConfigEntryAuthFailed
     except SurePetcareError as error:
         _LOGGER.error(
             "🐾 \x1b[38;2;255;26;102m·\x1b[0m unable to connect to surepetcare.io: %s",
@@ -104,10 +106,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     spc = SurePetcareAPI(hass, entry, surepy)
 
     async def async_update_data():
-
+        """Fetch data from Sure Petcare API."""
         try:
-            # asyncio.TimeoutError and aiohttp.ClientError already handled
-
             async with async_timeout.timeout(20):
                 return await spc.surepy.get_entities(refresh=True)
 
@@ -115,6 +115,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise ConfigEntryAuthFailed from err
         except SurePetcareError as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+        except Exception as err:
+            _LOGGER.error(f"Unexpected error during data update: {err}")
+            raise UpdateFailed(f"Unexpected error: {err}") from err
 
     spc.coordinator = DataUpdateCoordinator(
         hass,
@@ -126,9 +129,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await spc.coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][SPC] = spc
+    hass.data[DOMAIN][entry.entry_id] = spc
 
-    return await spc.async_setup()
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    await spc.async_setup()
+
+    return True
 
 
 class SurePetcareAPI:
@@ -140,21 +147,18 @@ class SurePetcareAPI:
         """Initialize the Sure Petcare object."""
 
         self.coordinator: DataUpdateCoordinator
-
         self.hass = hass
         self.config_entry = config_entry
         self.surepy = surepy
-
         self.states: dict[int, Any] = {}
 
     async def set_pet_location(self, pet_id: int, location: Location) -> None:
         """Update the lock state of a flap."""
-
         await self.surepy.sac.set_pet_location(pet_id, location)
+        await self.coordinator.async_request_refresh()
 
     async def set_lock_state(self, flap_id: int, state: str) -> None:
         """Update the lock state of a flap."""
-
         # https://github.com/PyCQA/pylint/issues/2062
         # pylint: disable=no-member
         lock_states = {
@@ -166,26 +170,127 @@ class SurePetcareAPI:
 
         # elegant functions dict to choose the right function | idea by @janiversen
         await lock_states[state.lower()](flap_id)
+        await self.coordinator.async_request_refresh()
+
+    # --- New Methods for Pet Mode ---
+    async def set_pet_indoor_mode(self, device_id: int, tag_id: int) -> None:
+        """Set a pet to indoor mode (profile_id=3) using tag_id."""
+        _LOGGER.debug(f"Calling surepy.sac.set_indoor_pet for tag_id: {tag_id}, device_id: {device_id}")
+        await self.surepy.sac.set_indoor_pet(device_id=device_id, tag_id=tag_id)
+        await self.coordinator.async_request_refresh()
+
+
+    async def set_pet_outdoor_mode(self, device_id: int, tag_id: int) -> None:
+        """Set a pet to outdoor mode (profile_id=2) using tag_id."""
+        _LOGGER.debug(f"Calling surepy.sac.set_outdoor_pet for tag_id: {tag_id}, device_id: {device_id}")
+        await self.surepy.sac.set_outdoor_pet(device_id=device_id, tag_id=tag_id)
+        await self.coordinator.async_request_refresh()
+    # --- End New Methods ---
 
     async def async_setup(self) -> bool:
-        """Set up the Sure Petcare integration."""
+        """Set up the Sure Petcare integration services."""
 
         _LOGGER.info("")
         _LOGGER.info(
             "%s %s", " \x1b[38;2;255;26;102m·\x1b[0m" * 24, choice(CATS)  # nosec
         )
-        _LOGGER.info("  🐾   meeowww..! to the SureHA integration!")
-        _LOGGER.info("  🐾     code & issues: https://github.com/benleb/sureha")
+        _LOGGER.info("  🐾    meeowww..! to the SureHA integration!")
+        _LOGGER.info("  🐾      code & issues: https://github.com/benleb/sureha")
         _LOGGER.info(" \x1b[38;2;255;26;102m·\x1b[0m" * 30)
         _LOGGER.info("")
-
-        await self.hass.config_entries.async_forward_entry_setups(self.config_entry, PLATFORMS)
 
         surepy_entities: list[SurepyEntity] = self.coordinator.data.values()
 
         pet_ids = [
             entity.id for entity in surepy_entities if entity.type == EntityType.PET
         ]
+
+        # --- Service Registration for Pet Mode ---
+        flap_ids = [
+            entity.id
+            for entity in surepy_entities
+            if entity.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP, EntityType.FEEDER]
+        ]
+        all_device_ids = sorted(list(set(flap_ids)))
+
+        set_indoor_pet_mode_schema = vol.Schema(
+            {
+                vol.Required(ATTR_PET_ID): vol.Any(cv.positive_int, vol.In(pet_ids)),
+                vol.Required("device_id"): vol.Any(cv.positive_int, vol.In(all_device_ids)),
+            }
+        )
+
+        async def handle_set_indoor_pet_mode(call: Any) -> None:
+            """Call when setting a pet to indoor mode."""
+            pet_id_from_service = call.data.get(ATTR_PET_ID) # This is the pet_id from the service call
+            device_id = call.data.get("device_id")
+
+            # --- NEW LOOKUP: Find the tag_id from the pet_id ---
+            tag_id_for_service = None
+            for entity_obj in self.coordinator.data.values():
+                if entity_obj.type == EntityType.PET and entity_obj.id == pet_id_from_service:
+                    tag_id_for_service = entity_obj.tag_id
+                    break
+
+            if tag_id_for_service is None:
+                _LOGGER.error(f"Could not find tag_id for pet_id: {pet_id_from_service}. Cannot set indoor mode.")
+                return
+            # --- END NEW LOOKUP ---
+
+            _LOGGER.info(f"Home Assistant service call: surepy.set_indoor_pet_mode for pet_id: {pet_id_from_service} (tag_id: {tag_id_for_service}), device_id: {device_id}")
+            try:
+                await self.set_pet_indoor_mode(device_id, tag_id_for_service)
+            except SurePetcareError as err:
+                _LOGGER.error(f"Failed to set pet {pet_id_from_service} on device {device_id} to indoor mode: {err}")
+            except Exception as err:
+                _LOGGER.exception(f"An unexpected error occurred while setting pet {pet_id_from_service} on device {device_id} to indoor mode: {err}")
+
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_INDOOR_PET_MODE,
+            handle_set_indoor_pet_mode,
+            schema=set_indoor_pet_mode_schema,
+        )
+
+        set_outdoor_pet_mode_schema = vol.Schema(
+            {
+                vol.Required(ATTR_PET_ID): vol.Any(cv.positive_int, vol.In(pet_ids)),
+                vol.Required("device_id"): vol.Any(cv.positive_int, vol.In(all_device_ids)),
+            }
+        )
+
+        async def handle_set_outdoor_pet_mode(call: Any) -> None:
+            """Call when setting a pet to outdoor mode."""
+            pet_id_from_service = call.data.get(ATTR_PET_ID) # This is the pet_id from the service call
+            device_id = call.data.get("device_id")
+
+            # --- NEW LOOKUP: Find the tag_id from the pet_id ---
+            tag_id_for_service = None
+            for entity_obj in self.coordinator.data.values():
+                if entity_obj.type == EntityType.PET and entity_obj.id == pet_id_from_service:
+                    tag_id_for_service = entity_obj.tag_id
+                    break
+
+            if tag_id_for_service is None:
+                _LOGGER.error(f"Could not find tag_id for pet_id: {pet_id_from_service}. Cannot set outdoor mode.")
+                return
+            # --- END NEW LOOKUP ---
+
+            _LOGGER.info(f"Home Assistant service call: surepy.set_outdoor_pet_mode for pet_id: {pet_id_from_service} (tag_id: {tag_id_for_service}), device_id: {device_id}")
+            try:
+                await self.set_pet_outdoor_mode(device_id, tag_id_for_service)
+            except SurePetcareError as err:
+                _LOGGER.error(f"Failed to set pet {pet_id_from_service} on device {device_id} to outdoor mode: {err}")
+            except Exception as err:
+                _LOGGER.exception(f"An unexpected error occurred while setting pet {pet_id_from_service} on device {device_id} to outdoor mode: {err}")
+
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_OUTDOOR_PET_MODE,
+            handle_set_outdoor_pet_mode,
+            schema=set_outdoor_pet_mode_schema,
+        )
+        # --- End Service Registration ---
 
         pet_location_service_schema = vol.Schema(
             {
@@ -208,13 +313,10 @@ class SurePetcareAPI:
             """Call when setting the lock state."""
 
             try:
-
                 if (pet_id := int(call.data.get(ATTR_PET_ID))) and (
                     where := str(call.data.get(ATTR_WHERE))
                 ):
-
                     await self.set_pet_location(pet_id, Location[where.upper()])
-                    await self.coordinator.async_request_refresh()
 
             except ValueError as error:
                 _LOGGER.error(
@@ -235,7 +337,6 @@ class SurePetcareAPI:
             lock_state = call.data.get(ATTR_LOCK_STATE)
 
             await self.set_lock_state(flap_id, lock_state)
-            await self.coordinator.async_request_refresh()
 
         flap_ids = [
             entity.id

--- a/custom_components/sureha/binary_sensor.py
+++ b/custom_components/sureha/binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -84,14 +84,12 @@ class SurePetcareBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
         self._coordinator = coordinator
 
-        self._surepy_entity: SurepyEntity = self._coordinator.data[self._id]
+        self._surepy_entity: SurepyEntity = self._coordinator.data[_id]
         self._state: Any = self._surepy_entity.raw_data().get("status", {})
 
         type_name = self._surepy_entity.type.name.replace("_", " ").title()
 
         self._name: str = (
-            # cover edge case where a device has no name set
-            # (dont know how to do this but people have managed to do it ¯\_(ツ)_/¯)
             self._surepy_entity.name
             if self._surepy_entity.name
             else f"Unnamed {type_name}"
@@ -188,13 +186,36 @@ class Pet(SurePetcareBinarySensor):
         super().__init__(coordinator, _id, spc, BinarySensorDeviceClass.PRESENCE)
 
         # explicit typing
-        self._surepy_entity: SurePet
+        self._surepy_entity: SurePet = cast(SurePet, self._surepy_entity) # Cast here for type hints
+
         self._pet_id = _id # Store pet ID
         self._tag_id = self._surepy_entity.tag_id # Store tag ID
+        self._spc = spc # Store spc for access to coordinator.data in __init__
 
-        # Get _device_id from raw_data['position']
-        # This ensures we identify the controlling device (e.g., flap) for this pet.
+        # --- REVISED LOGIC FOR _device_id in Pet Binary Sensor ---
+        # Determine _device_id in __init__ using the same robust logic as switch.py
+        # Prioritize flap association for mode control, as per user's requirement.
         self._device_id = self._surepy_entity.raw_data().get('position', {}).get('device_id')
+        _LOGGER.debug(f"Pet Binary Sensor Setup: Pet {self._surepy_entity.name} (ID: {self._pet_id}) initial _device_id from position: {self._device_id}")
+
+        if self._device_id is None and self._tag_id is not None:
+            _LOGGER.debug(f"Pet Binary Sensor Setup: _device_id is None for {self._surepy_entity.name}. Searching ALL FLAP devices for tag_id: {self._tag_id}")
+            
+            found_flap_id_init = None
+            for device_id, device_entity in spc.coordinator.data.items():
+                if isinstance(device_entity, SurepyDevice) and device_entity.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP]:
+                    device_raw_data = device_entity.raw_data()
+                    if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
+                        for tag_entry in device_raw_data['tags']:
+                            if tag_entry.get('id') == self._tag_id:
+                                found_flap_id_init = device_id
+                                _LOGGER.debug(f"Pet Binary Sensor Setup: Found tag {self._tag_id} on FLAP device {device_entity.name} (ID: {device_id}). Prioritizing this for _device_id.")
+                                break
+                        if found_flap_id_init:
+                            break
+            self._device_id = found_flap_id_init # Set _device_id to found flap ID, or None if no flap found.
+            _LOGGER.debug(f"Pet Binary Sensor Setup: Final _device_id for {self._surepy_entity.name}: {self._device_id}")
+        # --- END REVISED LOGIC ---
 
         # picture of the pet that can be added via the sure app/website
         self._attr_entity_picture = self._surepy_entity.photo_url
@@ -203,53 +224,61 @@ class Pet(SurePetcareBinarySensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the additional attrs."""
 
-        pet: SurePet = self._coordinator.data.get(self._pet_id) # Use .get() for safer access
+        pet: SurePet = cast(SurePet, self._coordinator.data.get(self._pet_id))
         if not pet:
             _LOGGER.debug(f"DEBUG: Pet {self._pet_id} not found in coordinator data for extra_state_attributes.")
-            return {} # Return empty if pet data is missing
+            return {} 
 
         attrs: dict[str, Any] = {
             "since": pet.location.since,
             "where": pet.location.where,
-            **pet.raw_data(), # Keep this to include other raw data from the pet
+            **pet.raw_data(), 
         }
-        profile_id = None # Initialize profile_id to None
+        profile_id = None 
 
-        # Use the stored _tag_id for consistency
         pet_tag_id = self._tag_id
         if not pet_tag_id:
             _LOGGER.debug(f"DEBUG: Pet {pet.name} (ID: {pet.id}) has no 'tag_id' associated. Cannot determine profile_id.")
-            return attrs # No tag_id means no profile_id can be found this way
+            return attrs 
 
-        # Prioritize checking the specific controlling device (flap/feeder) first
-        # This is the same logic that fixed the switch's state.
-        if self._device_id: # Only proceed if we have a controlling device ID
-            controlling_device_data = self.coordinator.data.get(self._device_id)
 
-            if controlling_device_data and 'tags' in controlling_device_data.raw_data() and isinstance(controlling_device_data.raw_data()['tags'], list):
+        # Use the _device_id determined in __init__ (which prioritizes flaps)
+        if self._device_id: 
+            controlling_device_data = self._spc.coordinator.data.get(self._device_id)
+
+            if controlling_device_data:
                 _LOGGER.debug(f"DEBUG: Checking PRIMARY controlling device {controlling_device_data.name} (ID: {controlling_device_data.id}, Type: {controlling_device_data.type}) for pet tag {pet_tag_id}.")
-                for tag_entry in controlling_device_data.raw_data()['tags']:
-                    if tag_entry.get('id') == pet_tag_id and tag_entry.get('profile') is not None:
-                        profile_id = tag_entry.get('profile')
-                        _LOGGER.debug(f"DEBUG: Found profile_id {profile_id} for pet {pet.name} from PRIMARY device {controlling_device_data.name}.")
-                        break # Found the profile on the primary device, no need to search further
+                device_raw_data = controlling_device_data.raw_data()
+                if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
+                    for tag_entry in device_raw_data['tags']:
+                        if tag_entry.get('id') == pet_tag_id and tag_entry.get('profile') is not None:
+                            profile_id = tag_entry.get('profile')
+                            _LOGGER.debug(f"DEBUG: Found profile_id {profile_id} for pet {pet.name} from PRIMARY device {controlling_device_data.name}.")
+                            break 
+                else:
+                     _LOGGER.debug(f"DEBUG: Controlling Device {controlling_device_data.name} has no 'tags' or invalid 'tags' data.")
+            else:
+                _LOGGER.warning(f"DEBUG: Controlling device (ID: {self._device_id}) not found in coordinator data for pet {self._surepy_entity.name}. Cannot determine state.")
 
-        # If profile_id is still not found after checking the primary controlling device,
-        # fallback to iterating all other relevant devices (less efficient, but covers edge cases)
+
+        # Fallback to iterating all *relevant* devices (flaps and feeders) for attributes
+        # This fallback for attributes should still check feeders, as they also have profiles
+        # but the primary lookup ensures the most relevant device (flap) is checked first
         if profile_id is None:
             _LOGGER.debug(f"DEBUG: Profile for {pet.name} not found on primary device {self._device_id}. Falling back to searching all relevant devices for tags.")
-            for entity_obj in self._coordinator.data.values():
-                # Only check devices that are flaps/feeders and are NOT the primary controlling device
-                if entity_obj.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP, EntityType.FEEDER] and entity_obj.id != self._device_id:
-                    device_raw_data = entity_obj.raw_data()
-                    if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
-                        for tag_entry in device_raw_data['tags']:
-                            if tag_entry.get('id') == pet_tag_id and tag_entry.get('profile') is not None:
-                                profile_id = tag_entry.get('profile')
-                                _LOGGER.debug(f"DEBUG: Found profile_id {profile_id} for pet {pet.name} from SECONDARY device {entity_obj.name} (ID: {entity_obj.id}).")
-                                break # Found the profile, exit inner loop
-                        if profile_id is not None:
-                            break # Found the profile, exit outer loop (device loop)
+            for entity_obj in self._spc.coordinator.data.values(): 
+                if isinstance(entity_obj, SurepyDevice) and entity_obj.id != self._device_id:
+                    # Check both flaps and feeders for profile attributes
+                    if entity_obj.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP, EntityType.FEEDER]:
+                        device_raw_data = entity_obj.raw_data()
+                        if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
+                            for tag_entry in device_raw_data['tags']:
+                                if tag_entry.get('id') == pet_tag_id and tag_entry.get('profile') is not None:
+                                    profile_id = tag_entry.get('profile')
+                                    _LOGGER.debug(f"DEBUG: Found profile_id {profile_id} for pet {pet.name} from SECONDARY device {entity_obj.name} (ID: {entity_obj.id}).")
+                                    break 
+                            if profile_id is not None:
+                                break 
 
         # Assign profile_id and pet_mode if a valid profile_id was found
         if profile_id is not None:
@@ -259,7 +288,6 @@ class Pet(SurePetcareBinarySensor):
             elif profile_id == 2:
                 attrs["pet_mode"] = "Outdoor"
             else:
-                # Handle other potential profile_ids if they exist and are meaningful
                 attrs["pet_mode"] = f"Unknown Profile (ID: {profile_id})"
         else:
             _LOGGER.debug(f"DEBUG: Could not find profile_id for pet {pet.name} (ID: {pet.id}) after searching all relevant devices.")
@@ -269,10 +297,11 @@ class Pet(SurePetcareBinarySensor):
     @property
     def is_on(self) -> bool:
         """Return True if the pet is at home."""
+
         pet: SurePet
         inside: bool = False
 
-        if pet := self._coordinator.data.get(self._id): # Use .get() for safer access
+        if pet := cast(SurePet, self._coordinator.data.get(self._id)): 
             inside = bool(pet.location.where == Location.INSIDE)
 
         return inside
@@ -298,11 +327,14 @@ class DeviceConnectivity(SurePetcareBinarySensor):
         device: SurepyDevice
         attrs: dict[str, Any] = {}
 
-        if (device := self._coordinator.data[self._id]) and (
-            state := device.raw_data().get("status", {})
+        if (device := cast(SurepyDevice, self._coordinator.data.get(self._id))) and ( # Use .get() for safer access
+            state := device.raw_data().get("status")
         ) and (bool(state.get("online", False))):
             device_rssi = state.get("signal", {}).get("device_rssi")
-            self._attr_extra_state_attributes["device_rssi"] = f"{device_rssi:.2f}" if device_rssi else "Unknown"
+            # Ensure _attr_extra_state_attributes is initialized if it wasn't by base class
+            if not hasattr(self, '_attr_extra_state_attributes'):
+                self._attr_extra_state_attributes = {}
+            self._attr_extra_state_attributes["device_rssi"] = f"{device_rssi:.2f}" if device_rssi is not None else "Unknown" # Check for None
             hub_rssi = state.get("signal", {}).get("hub_rssi")
             if hub_rssi is not None:
                 self._attr_extra_state_attributes["hub_rssi"] = f"{hub_rssi:.2f}"
@@ -317,4 +349,8 @@ class DeviceConnectivity(SurePetcareBinarySensor):
     @property
     def is_on(self) -> bool:
         """Return True if the pet is at home."""
-        return bool(self.extra_state_attributes)
+        # It's safer to directly check the 'online' status for connectivity, not just extra_state_attributes
+        device = cast(SurepyDevice, self._coordinator.data.get(self._id))
+        if device and (status := device.raw_data().get("status")):
+            return bool(status.get("online", False))
+        return False # Default to False if data is missing or device is not online

--- a/custom_components/sureha/binary_sensor.py
+++ b/custom_components/sureha/binary_sensor.py
@@ -1,7 +1,10 @@
 """Support for Sure PetCare Flaps/Pets binary sensors."""
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -39,7 +42,7 @@ async def async_setup_entry(
 
     entities: list[SurePetcareBinarySensor] = []
 
-    spc: SurePetcareAPI = hass.data[DOMAIN][SPC]
+    spc: SurePetcareAPI = hass.data[DOMAIN][config_entry.entry_id]
 
     for surepy_entity in spc.coordinator.data.values():
 
@@ -88,7 +91,7 @@ class SurePetcareBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
         self._name: str = (
             # cover edge case where a device has no name set
-            # (dont know how to do this but people have managed to do it  ¯\_(ツ)_/¯)
+            # (dont know how to do this but people have managed to do it ¯\_(ツ)_/¯)
             self._surepy_entity.name
             if self._surepy_entity.name
             else f"Unnamed {type_name}"
@@ -186,6 +189,12 @@ class Pet(SurePetcareBinarySensor):
 
         # explicit typing
         self._surepy_entity: SurePet
+        self._pet_id = _id # Store pet ID
+        self._tag_id = self._surepy_entity.tag_id # Store tag ID
+
+        # Get _device_id from raw_data['position']
+        # This ensures we identify the controlling device (e.g., flap) for this pet.
+        self._device_id = self._surepy_entity.raw_data().get('position', {}).get('device_id')
 
         # picture of the pet that can be added via the sure app/website
         self._attr_entity_picture = self._surepy_entity.photo_url
@@ -194,27 +203,76 @@ class Pet(SurePetcareBinarySensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the additional attrs."""
 
-        pet: SurePet
-        attrs: dict[str, Any] = {}
+        pet: SurePet = self._coordinator.data.get(self._pet_id) # Use .get() for safer access
+        if not pet:
+            _LOGGER.debug(f"DEBUG: Pet {self._pet_id} not found in coordinator data for extra_state_attributes.")
+            return {} # Return empty if pet data is missing
 
-        if pet := self._coordinator.data[self._id]:
+        attrs: dict[str, Any] = {
+            "since": pet.location.since,
+            "where": pet.location.where,
+            **pet.raw_data(), # Keep this to include other raw data from the pet
+        }
+        profile_id = None # Initialize profile_id to None
 
-            attrs = {
-                "since": pet.location.since,
-                "where": pet.location.where,
-                **pet.raw_data(),
-            }
+        # Use the stored _tag_id for consistency
+        pet_tag_id = self._tag_id
+        if not pet_tag_id:
+            _LOGGER.debug(f"DEBUG: Pet {pet.name} (ID: {pet.id}) has no 'tag_id' associated. Cannot determine profile_id.")
+            return attrs # No tag_id means no profile_id can be found this way
+
+        # Prioritize checking the specific controlling device (flap/feeder) first
+        # This is the same logic that fixed the switch's state.
+        if self._device_id: # Only proceed if we have a controlling device ID
+            controlling_device_data = self.coordinator.data.get(self._device_id)
+
+            if controlling_device_data and 'tags' in controlling_device_data.raw_data() and isinstance(controlling_device_data.raw_data()['tags'], list):
+                _LOGGER.debug(f"DEBUG: Checking PRIMARY controlling device {controlling_device_data.name} (ID: {controlling_device_data.id}, Type: {controlling_device_data.type}) for pet tag {pet_tag_id}.")
+                for tag_entry in controlling_device_data.raw_data()['tags']:
+                    if tag_entry.get('id') == pet_tag_id and tag_entry.get('profile') is not None:
+                        profile_id = tag_entry.get('profile')
+                        _LOGGER.debug(f"DEBUG: Found profile_id {profile_id} for pet {pet.name} from PRIMARY device {controlling_device_data.name}.")
+                        break # Found the profile on the primary device, no need to search further
+
+        # If profile_id is still not found after checking the primary controlling device,
+        # fallback to iterating all other relevant devices (less efficient, but covers edge cases)
+        if profile_id is None:
+            _LOGGER.debug(f"DEBUG: Profile for {pet.name} not found on primary device {self._device_id}. Falling back to searching all relevant devices for tags.")
+            for entity_obj in self._coordinator.data.values():
+                # Only check devices that are flaps/feeders and are NOT the primary controlling device
+                if entity_obj.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP, EntityType.FEEDER] and entity_obj.id != self._device_id:
+                    device_raw_data = entity_obj.raw_data()
+                    if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
+                        for tag_entry in device_raw_data['tags']:
+                            if tag_entry.get('id') == pet_tag_id and tag_entry.get('profile') is not None:
+                                profile_id = tag_entry.get('profile')
+                                _LOGGER.debug(f"DEBUG: Found profile_id {profile_id} for pet {pet.name} from SECONDARY device {entity_obj.name} (ID: {entity_obj.id}).")
+                                break # Found the profile, exit inner loop
+                        if profile_id is not None:
+                            break # Found the profile, exit outer loop (device loop)
+
+        # Assign profile_id and pet_mode if a valid profile_id was found
+        if profile_id is not None:
+            attrs["profile_id"] = profile_id
+            if profile_id == 3:
+                attrs["pet_mode"] = "Indoor Only"
+            elif profile_id == 2:
+                attrs["pet_mode"] = "Outdoor"
+            else:
+                # Handle other potential profile_ids if they exist and are meaningful
+                attrs["pet_mode"] = f"Unknown Profile (ID: {profile_id})"
+        else:
+            _LOGGER.debug(f"DEBUG: Could not find profile_id for pet {pet.name} (ID: {pet.id}) after searching all relevant devices.")
 
         return attrs
 
     @property
     def is_on(self) -> bool:
         """Return True if the pet is at home."""
-
         pet: SurePet
         inside: bool = False
 
-        if pet := self._coordinator.data[self._id]:
+        if pet := self._coordinator.data.get(self._id): # Use .get() for safer access
             inside = bool(pet.location.where == Location.INSIDE)
 
         return inside

--- a/custom_components/sureha/const.py
+++ b/custom_components/sureha/const.py
@@ -27,3 +27,6 @@ ATTR_LOCK_STATE = "lock_state"
 SERVICE_PET_LOCATION = "set_pet_location"
 ATTR_PET_ID = "pet_id"
 ATTR_WHERE = "where"
+
+SERVICE_SET_INDOOR_PET_MODE = "set_indoor_pet_mode"
+SERVICE_SET_OUTDOOR_PET_MODE = "set_outdoor_pet_mode"

--- a/custom_components/sureha/device_tracker.py
+++ b/custom_components/sureha/device_tracker.py
@@ -21,7 +21,7 @@ SOURCE_TYPE_FLAP = "flap"
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Pet tracker from config entry."""
 
-    spc: SurePetcareAPI = hass.data[DOMAIN][SPC]
+    spc: SurePetcareAPI = hass.data[DOMAIN][config_entry.entry_id]
 
     async_add_entities(
         [

--- a/custom_components/sureha/sensor.py
+++ b/custom_components/sureha/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import pprint
-import random
 from typing import Any, cast
 
 from homeassistant.components.sensor import (
@@ -78,27 +77,30 @@ async def async_setup_entry(
             entities.append(Felaqua(spc.coordinator, surepy_entity.id, spc))
 
         elif surepy_entity.type == EntityType.FEEDER:
-
-            bowls = {}
-
-            if len(surepy_entity.bowls) > 0:
-                bowls = surepy_entity.bowls.values()
-            else:
-                if surepy_entity.raw_data()["control"].get("bowls"):
-                    bowls = surepy_entity.raw_data()["control"]["bowls"]
-
             _LOGGER.debug(
-                "%s| bowls (%d): %s",
-                surepy_entity.raw_data()["name"],
-                len(bowls),
-                pprint.pformat(bowls),
+                "DEBUG async_setup_entry: Setting up Feeder entity for %s (ID: %s)",
+                surepy_entity.name,
+                surepy_entity.id,
             )
 
-            for bowl in bowls.get("settings", []):
-                entities.append(
-                    FeederBowl(spc.coordinator, surepy_entity.id, spc, bowl)
-                    # FeederBowl(spc.coordinator, surepy_entity.id, spc, bowl.raw_data())
+            # --- Ensure FeederBowl entities are created from SureFeederBowl objects ---
+            # This is the most reliable way to get bowl data
+            if surepy_entity.bowls:
+                _LOGGER.debug(
+                    "DEBUG async_setup_entry: Found %d SureFeederBowl objects for Feeder ID %s. Creating FeederBowl sensors.",
+                    len(surepy_entity.bowls),
+                    surepy_entity.id,
                 )
+                for bowl_entity in surepy_entity.bowls.values():
+                    entities.append(
+                        FeederBowl(spc.coordinator, surepy_entity.id, spc, bowl_entity)
+                    )
+            else:
+                _LOGGER.warning(
+                    "WARNING async_setup_entry: No SureFeederBowl objects found in surepy_entity.bowls for Feeder ID: %s. Feeder bowl sensors will not be created.",
+                    surepy_entity.id
+                )
+                # Removed any fallback to raw data to prevent unknown/duplicate sensors
 
             entities.append(Feeder(spc.coordinator, surepy_entity.id, spc))
 
@@ -107,8 +109,8 @@ async def async_setup_entry(
             EntityType.PET_FLAP,
             EntityType.FEEDER,
             EntityType.FELAQUA,
-        ] and surepy_entity.raw_data().get("status", {}).get("battery", {}):
-
+        ] and surepy_entity.raw_data().get("status", {}).get("battery") is not None:
+            # Check if 'battery' key exists and is not None in raw_data().get("status")
             voltage_batteries_full = cast(
                 float,
                 config_entry.options.get(ATTR_VOLTAGE_FULL, SURE_BATT_VOLTAGE_FULL),
@@ -127,7 +129,8 @@ async def async_setup_entry(
                 )
             )
 
-    async_add_entities(entities)
+    # Make sure this is set to True!
+    async_add_entities(entities, True)
 
 
 class SurePetcareSensor(CoordinatorEntity, SensorEntity):
@@ -144,12 +147,18 @@ class SurePetcareSensor(CoordinatorEntity, SensorEntity):
 
         self._coordinator = coordinator
 
+        # Ensure that self._surepy_entity is correctly assigned from coordinator data
+        # This will be the source of truth for all entity properties derived from surepy
         self._surepy_entity: SurepyEntity = self._coordinator.data[_id]
+        
+        # Initial status data for availability check and attributes.
+        # It's important to use the latest status during coordinator updates.
         self._state: dict[str, Any] = self._surepy_entity.raw_data()["status"]
 
-        self._attr_available = bool(self._state)
+        self._attr_available = bool(self._state) # Basic availability based on status presence
         self._attr_unique_id = f"{self._surepy_entity.household_id}-{self._id}"
 
+        # Initial extra_state_attributes; will be updated by extra_state_attributes property
         self._attr_extra_state_attributes = (
             {**self._surepy_entity.raw_data()} if self._state else {}
         )
@@ -207,7 +216,7 @@ class Flap(SurePetcareSensor):
     def __init__(self, coordinator, _id: int, spc: SurePetcareAPI) -> None:
         super().__init__(coordinator, _id, spc)
 
-        self._surepy_entity: SureFlap
+        self._surepy_entity = cast(SureFlap, self._surepy_entity) # Type hint for specific entity type
 
         self._attr_entity_picture = self._surepy_entity.icon
         self._attr_unit_of_measurement = None
@@ -217,19 +226,18 @@ class Flap(SurePetcareSensor):
                 "learn_mode": bool(self._state["learn_mode"]),
                 **self._surepy_entity.raw_data(),
             }
-
+            # Set initial state if available
             if locking := self._state.get("locking"):
                 self._attr_state = LockState(locking["mode"]).name.casefold()
 
     @property
     def state(self) -> str | None:
-        """Return battery level in percent."""
-        if (
-            state := cast(SureFlap, self._coordinator.data[self._id])
-            .raw_data()
-            .get("status")
-        ):
+        """Return lock state."""
+        # Get the latest data from the coordinator
+        current_entity = cast(SureFlap, self._coordinator.data.get(self._id))
+        if current_entity and (state := current_entity.raw_data().get("status")):
             return LockState(state["locking"]["mode"]).name.casefold()
+        return None
 
 
 class Felaqua(SurePetcareSensor):
@@ -238,7 +246,7 @@ class Felaqua(SurePetcareSensor):
     def __init__(self, coordinator, _id: int, spc: SurePetcareAPI):
         super().__init__(coordinator, _id, spc)
 
-        self._surepy_entity: SureFelaqua
+        self._surepy_entity = cast(SureFelaqua, self._surepy_entity) # Type hint for specific entity type
 
         self._attr_entity_picture = self._surepy_entity.icon
         self._attr_unit_of_measurement = UnitOfVolume.MILLILITERS
@@ -246,8 +254,11 @@ class Felaqua(SurePetcareSensor):
     @property
     def state(self) -> float | None:
         """Return the remaining water."""
-        if felaqua := cast(SureFelaqua, self._coordinator.data[self._id]):
-            return int(felaqua.water_remaining) if felaqua.water_remaining else None
+        # Get the latest data from the coordinator
+        current_entity = cast(SureFelaqua, self._coordinator.data.get(self._id))
+        if current_entity:
+            return int(current_entity.water_remaining) if current_entity.water_remaining is not None else None
+        return None
 
 
 class FeederBowl(SurePetcareSensor):
@@ -258,84 +269,138 @@ class FeederBowl(SurePetcareSensor):
         coordinator,
         _id: int,
         spc: SurePetcareAPI,
-        bowl_data: dict[str, int | str],
+        bowl_entity: SureFeederBowl, # <--- Now strictly SureFeederBowl
     ):
         """Initialize a Bowl sensor."""
         super().__init__(coordinator, _id, spc)
 
-        _LOGGER.debug("bowl_data: %s", pprint.pformat(bowl_data))
+        _LOGGER.debug("DEBUG FeederBowl __init__: Received SureFeederBowl object: %s", pprint.pformat(bowl_entity.raw_data()))
 
         self.feeder_id = _id
+        self._bowl_entity: SureFeederBowl = bowl_entity # Store the actual SureFeederBowl object
 
-        # todo: index parameter is not available in the bowl_data anymore
-        # for now we use a random number...
-        self.bowl_id = random.randint(
-            1, 10
-        )  # int(bowl_data.get("index", random.randint(1, 10)))
+        self.bowl_id = self._bowl_entity.id # Use the stable ID from the SureFeederBowl object
+        self._bowl_index = self._bowl_entity.index # This is also stable (e.g., 0 or 1 for dual bowls)
 
-        self._id = int(f"{_id}{str(self.bowl_id)}")
         self._spc: SurePetcareAPI = spc
 
         self._surepy_feeder_entity: SurepyEntity = self._coordinator.data[_id]
 
-        self._state: dict[str, Any] = bowl_data
-
-        # https://github.com/PyCQA/pylint/issues/2062
-        # pylint: disable=no-member
+        # Use index for naming. Add 1 for user-friendly 1-based indexing if preferred.
         self._attr_name = (
             f"{EntityType.FEEDER.name.replace('_', ' ').title()} "
-            f"{self._surepy_entity.name.capitalize()}"
+            f"{self._surepy_feeder_entity.name.capitalize()} Bowl {self._bowl_entity.index + 1}"
         )
 
         self._attr_icon = "mdi:bowl"
-
-        if hasattr(self._surepy_entity, "weight"):
-            self._attr_state = int(self._surepy_entity.weight)
-
-        self._attr_unique_id = (
-            f"{self._surepy_feeder_entity.household_id}-{self.feeder_id}-{self.bowl_id}"
-        )
         self._attr_unit_of_measurement = UnitOfMass.GRAMS
+
+        # Unique ID using the stable bowl_id from SureFeederBowl object
+        self._attr_unique_id = (
+            f"{self._surepy_feeder_entity.household_id}-{self.feeder_id}-bowl-{self.bowl_id}"
+        )
+        _LOGGER.debug(
+            "DEBUG FeederBowl __init__: Initialized FeederBowl entity for Feeder ID: %s, Bowl ID: %s, Unique ID: %s, Name: %s",
+            self.feeder_id,
+            self.bowl_id,
+            self._attr_unique_id,
+            self._attr_name
+        )
 
     @property
     def state(self) -> float | None:
-        """Return the remaining water."""
-
-        _LOGGER.debug(
-            "self._coordinator.data[%d]: %s",
-            self.feeder_id,
-            pprint.pformat(self._coordinator.data[self.feeder_id]),
-        )
-
-        if (
-            (feeder := cast(SureFeeder, self._coordinator.data[self.feeder_id]))
-            and len(feeder.bowls) > 0
-            and hasattr(feeder.bowls[self.bowl_id], "weight")
-            and (weight := feeder.bowls[self.bowl_id].weight)
-        ):
-            return int(weight) if weight and weight > 0 else None
+        """Return the remaining food in the bowl."""
+        _LOGGER.debug(f"DEBUG FeederBowl.state: Attempting to get state for Bowl ID: {self.bowl_id} (Unique ID: {self._attr_unique_id})")
+        
+        # Get the latest feeder data from the coordinator
+        feeder = cast(SureFeeder, self._coordinator.data.get(self.feeder_id))
+        
+        if feeder and self.bowl_id in feeder.bowls:
+            bowl = feeder.bowls[self.bowl_id]
+            if bowl.weight is not None:
+                _LOGGER.debug(f"DEBUG FeederBowl.state: Found bowl weight for ID {self.bowl_id}: {bowl.weight}")
+                return int(bowl.weight)
+            else:
+                _LOGGER.debug(f"DEBUG FeederBowl.state: Bowl weight is None for ID {self.bowl_id}. Returning None.")
+        else:
+            _LOGGER.debug(f"DEBUG FeederBowl.state: Bowl ID {self.bowl_id} not found in feeder.bowls or feeder is None. Returning None.")
+        
+        return None
 
 
 class Feeder(SurePetcareSensor):
     """Sure Petcare Feeder."""
 
     def __init__(self, coordinator, _id: int, spc: SurePetcareAPI):
+        """Initialize a Feeder sensor."""
         super().__init__(coordinator, _id, spc)
 
-        self._surepy_entity: SureFeeder
+        self._surepy_entity = cast(SureFeeder, self._surepy_entity) # Type hint for specific entity type
 
         self._attr_entity_picture = self._surepy_entity.icon
         self._attr_unit_of_measurement = UnitOfMass.GRAMS
 
+        # Add or modify unique_id explicitly for Feeder to be highly distinct
+        self._attr_unique_id = (
+            f"{self._surepy_entity.household_id}-{self._id}-total_food"
+        )
+
+        # Add this debug log for initial state/entity details
+        _LOGGER.debug(
+            "DEBUG Feeder __init__: Initializing Feeder entity for ID: %s, Name: %s, Unique ID: %s. Raw Data Status: %s",
+            self._id,
+            self._surepy_entity.name,
+            self._attr_unique_id,  # Log the unique ID too
+            pprint.pformat(self._surepy_entity.raw_data().get("status", "Status key not found in raw_data")),
+        )
+
     @property
     def state(self) -> float | None:
         """Return the total remaining food."""
-        if feeder := cast(SureFeeder, self._coordinator.data[self._id]):
-            return int(feeder.total_weight) if feeder.total_weight else None
+        _LOGGER.debug(
+            "DEBUG Feeder.state: Attempting to get state for entity ID: %s (Unique ID: %s)",
+            self._id,
+            self._attr_unique_id,
+        )
+
+        # Use .get() for safer access to avoid KeyError if _id isn't in data
+        feeder = cast(SureFeeder, self._coordinator.data.get(self._id))
+
+        if feeder:
+            _LOGGER.debug(
+                "DEBUG Feeder.state: Feeder data found for ID %s. total_weight: %s (Type: %s). Raw data (status key): %s",
+                self._id,
+                feeder.total_weight,
+                type(feeder.total_weight),
+                pprint.pformat(feeder.raw_data().get("status", "Status key not found in raw_data")),
+            )
+
+            if feeder.total_weight is not None:
+                try:
+                    return int(feeder.total_weight)  # Return the actual integer value, even if it's 0
+                except (ValueError, TypeError) as e:
+                    _LOGGER.error(
+                        "ERROR Feeder.state: Could not convert total_weight '%s' (type %s) to int for entity ID %s. Error: %s",
+                        feeder.total_weight,
+                        type(feeder.total_weight),
+                        self._id,
+                        e
+                    )
+                    return None  # If conversion fails, then it's truly unavailable
+            else:
+                _LOGGER.debug(
+                    "DEBUG Feeder.state: total_weight is None for entity ID: %s", self._id
+                )
+                return None  # If total_weight is None from the API, then the sensor is truly unavailable
+        else:
+            _LOGGER.debug(
+                "DEBUG Feeder.state: No feeder data found in coordinator.data for entity ID: %s. Entity might be unavailable.", self._id
+            )
+            return None
 
 
 class Battery(SurePetcareSensor):
-    """Sure Petcare Flap."""
+    """Sure Petcare Battery Sensor."""
 
     def __init__(
         self,
@@ -347,34 +412,73 @@ class Battery(SurePetcareSensor):
     ):
         super().__init__(coordinator, _id, spc)
 
-        self._surepy_entity: SurepyDevice
+        self._surepy_entity = cast(SurepyDevice, self._surepy_entity) # Type hint for specific entity type
 
+        # Set these attributes in __init__
         self._attr_name = f"{self._attr_name} Battery Level"
-
-        self.voltage_low = voltage_low
-        self.voltage_full = voltage_full
-
         self._attr_unit_of_measurement = PERCENTAGE
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_unique_id = (
             f"{self._surepy_entity.household_id}-{self._surepy_entity.id}-battery"
         )
 
+        self.voltage_low = voltage_low
+        self.voltage_full = voltage_full
+
+        # Add debug log for Battery __init__
+        _LOGGER.debug(
+            "DEBUG Battery __init__: Initializing Battery entity for ID: %s, Name: %s, Unique ID: %s. Voltage Full: %s, Voltage Low: %s. Raw Data Status: %s",
+            self._id,
+            self._attr_name,
+            self._attr_unique_id,
+            self.voltage_full,
+            self.voltage_low,
+            pprint.pformat(self._surepy_entity.raw_data().get("status", "Status key not found in raw_data")),
+        )
+
+
     @property
     def state(self) -> int | None:
         """Return battery level in percent."""
+        _LOGGER.debug(f"DEBUG Battery.state: Attempting to get state for battery ID: {self._id} (Unique ID: {self._attr_unique_id})")
 
-        if battery := cast(SurepyDevice, self._coordinator.data[self._id]):
+        # Get the latest device data from the coordinator
+        device_data = self._coordinator.data.get(self._id)
+        if not device_data:
+            _LOGGER.debug(f"DEBUG Battery.state: No device data found in coordinator for ID: {self._id}. Sensor likely unavailable.")
+            return None # Sensor is truly unavailable if no device data in coordinator
 
-            self._surepy_entity = battery
-            self.device_class = SensorDeviceClass.BATTERY
-            self.native_unit_of_measurement = PERCENTAGE
-            battery_level = battery.calculate_battery_level(
-                voltage_full=self.voltage_full, voltage_low=self.voltage_low
-            )
+        # Ensure we are working with a SurepyDevice type for its methods
+        battery_device = cast(SurepyDevice, device_data)
+        
+        # Log the raw status data from the device to confirm voltage presence
+        raw_status = battery_device.raw_data().get("status")
+        if raw_status:
+            _LOGGER.debug(f"DEBUG Battery.state: Device ID {self._id} raw status: {pprint.pformat(raw_status)}")
+        else:
+            _LOGGER.debug(f"DEBUG Battery.state: Device ID {self._id} has no 'status' key in raw_data. Cannot determine battery level.")
+            return None # If no status, cannot get battery level
 
-            # return batterie level between 0 and 100
-            return battery_level
+        # Call calculate_battery_level from the SurepyDevice object
+        battery_level = battery_device.calculate_battery_level(
+            voltage_full=self.voltage_full,
+            voltage_low=self.voltage_low
+        )
+
+        _LOGGER.debug(
+            f"DEBUG Battery.state: Device ID {self._id} (Name: {self._attr_name}): "
+            f"Calculated battery level: {battery_level} "
+            f"using voltage_full={self.voltage_full}, voltage_low={self.voltage_low}."
+        )
+
+        # Surepy's calculate_battery_level returns an int or None
+        if battery_level is not None:
+            # Ensure the level is within expected bounds (0-100)
+            return max(0, min(100, battery_level))
+        
+        _LOGGER.warning(f"WARNING Battery.state: battery_level is None for device ID {self._id}. This means Surepy's calculate_battery_level returned None.")
+        return None
+
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -382,17 +486,24 @@ class Battery(SurePetcareSensor):
 
         attrs = {}
 
-        if (device := cast(SurepyDevice, self._coordinator.data[self._id])) and (
-            state := device.raw_data().get("status")
-        ):
-            self._surepy_entity = device
+        # Get the latest device data from the coordinator.
+        # This ensures attributes reflect current state, not just __init__ state.
+        device_data = self._coordinator.data.get(self._id)
 
-            voltage = float(state["battery"])
+        if (device_data) and (
+            state := device_data.raw_data().get("status")
+        ):
+            # Use .get() with a default value to prevent KeyError if 'battery' is missing
+            voltage = float(state.get("battery", 0.0)) 
 
             attrs = {
-                "battery_level": device.battery_level,
+                # Use battery_device.battery_level property from surepy for consistency
+                "battery_level_from_surepy": device_data.battery_level, 
                 ATTR_VOLTAGE: f"{voltage:.2f}",
-                f"{ATTR_VOLTAGE}_per_battery": f"{voltage / 4:.2f}",
+                # Only show per_battery if voltage is non-zero to avoid division by zero
+                f"{ATTR_VOLTAGE}_per_battery": f"{voltage / 4:.2f}" if voltage else "0.00", 
             }
+        
+        _LOGGER.debug(f"DEBUG Battery.extra_state_attributes: For ID {self._id}, attributes: {attrs}")
 
         return attrs

--- a/custom_components/sureha/sensor.py
+++ b/custom_components/sureha/sensor.py
@@ -64,7 +64,7 @@ async def async_setup_entry(
 
     entities: list[Flap | Felaqua | Feeder | FeederBowl | Battery] = []
 
-    spc: SurePetcareAPI = hass.data[DOMAIN][SPC]
+    spc: SurePetcareAPI = hass.data[DOMAIN][config_entry.entry_id]
 
     for surepy_entity in spc.coordinator.data.values():
 

--- a/custom_components/sureha/services.yaml
+++ b/custom_components/sureha/services.yaml
@@ -33,3 +33,47 @@ set_pet_location:
       required: true
       example: "Inside"
       selector: { select: { options: ["Inside", "Outside"] } }
+set_indoor_pet_mode:
+  name: Set Pet Indoor Only Mode
+  description: Sets a pet's profile to "indoor only" to prevent using the flap.
+  fields:
+    pet_id:
+      name: Pet ID
+      description: The ID of the pet to set to indoor only mode.
+      required: true
+      example: 31337
+      selector:
+        number:
+          min: 1
+          mode: box
+    device_id:
+      name: Device ID
+      description: The ID of the flap or feeder associated with the pet.
+      required: true
+      example: 123456
+      selector:
+        number:
+          min: 1
+          mode: box
+set_outdoor_pet_mode:
+  name: Set Pet Outdoor Mode
+  description: Sets a pet's profile to "outdoor" to allow using the flap.
+  fields:
+    pet_id:
+      name: Pet ID
+      description: The ID of the pet to set to outdoor mode.
+      required: true
+      example: 31337
+      selector:
+        number:
+          min: 1
+          mode: box
+    device_id:
+      name: Device ID
+      description: The ID of the flap or feeder associated with the pet.
+      required: true
+      example: 123456
+      selector:
+        number:
+          min: 1
+          mode: box

--- a/custom_components/sureha/switch.py
+++ b/custom_components/sureha/switch.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import logging
-import asyncio # Keep this import
+import asyncio 
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import DOMAIN, SurePetcareAPI
 from surepy.entities import SurepyEntity
 from surepy.entities.pet import Pet as SurePet
+from surepy.entities.devices import SurepyDevice # Import SurepyDevice for type checking
 from surepy.enums import EntityType
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,16 +32,48 @@ async def async_setup_entry(
     entities = []
     for _id, entity in spc.coordinator.data.items():
         if isinstance(entity, SurePet):
-            # Get the tag_id and the associated device_id from raw_data
             pet_tag_id = entity.tag_id
-            # Get associated_device_id from raw_data['position']
-            associated_device_id = entity.raw_data().get('position', {}).get('device_id')
+            pet_name = entity.name
+            pet_id = entity.id
 
+            # 1. Try to get associated_device_id from raw_data['position'] (primary method)
+            associated_device_id = entity.raw_data().get('position', {}).get('device_id')
+            _LOGGER.debug(f"Switch Setup: Pet {pet_name} (ID: {pet_id}) initial associated_device_id from position: {associated_device_id}")
+
+            # 2. If primary method fails and tag_id exists, fall back to searching all FLAP devices for the tag_id
+            if associated_device_id is None and pet_tag_id is not None:
+                _LOGGER.debug(f"Switch Setup: associated_device_id is None for {pet_name}. Searching ALL FLAP devices for tag_id: {pet_tag_id}")
+                
+                found_flap_id = None # We only care about flaps for the switch
+
+                for device_id, device_entity in spc.coordinator.data.items():
+                    # Only consider flap-type devices for the switch's control
+                    if isinstance(device_entity, SurepyDevice) and device_entity.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP]:
+                        device_raw_data = device_entity.raw_data()
+                        if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
+                            for tag_entry in device_raw_data['tags']:
+                                if tag_entry.get('id') == pet_tag_id:
+                                    found_flap_id = device_id
+                                    _LOGGER.debug(f"Switch Setup: Found tag {pet_tag_id} on FLAP device {device_entity.name} (ID: {device_id}). Prioritizing this for switch.")
+                                    break # Found on a flap, prioritize this one and exit inner loop
+                            if found_flap_id: # If found on a flap, no need to check other devices
+                                break
+
+                if found_flap_id:
+                    associated_device_id = found_flap_id
+                else:
+                    _LOGGER.debug(f"Switch Setup: No associated FLAP found for {pet_name} (tag_id: {pet_tag_id}). Switch will not be created.")
+                    # associated_device_id remains None if no flap is found, preventing switch creation
+
+            # Add the switch only if a tag_id exists AND a valid associated_device_id (from a flap) was found
             if pet_tag_id is not None and associated_device_id is not None:
-                _LOGGER.debug(f"Adding switch for pet {entity.name} (ID: {entity.id}, Tag ID: {pet_tag_id}, Device ID: {associated_device_id})")
+                _LOGGER.debug(f"Adding switch for pet {pet_name} (ID: {pet_id}, Tag ID: {pet_tag_id}, Final Device ID: {associated_device_id})")
                 entities.append(SurePetModeSwitch(spc, entity))
             else:
-                _LOGGER.debug(f"Skipping switch for pet {entity.name} (ID: {entity.id}): tag_id ({pet_tag_id}) or associated device_id ({associated_device_id}) is missing. This pet may not be linked to a flap or feeder.")
+                _LOGGER.debug(
+                    f"Skipping switch for pet {pet_name} (ID: {pet_id}): tag_id ({pet_tag_id}) or final associated FLAP device_id ({associated_device_id}) is missing. "
+                    f"This pet may not be linked to a flap for mode control. Full raw_data: {entity.raw_data()}"
+                )
 
     async_add_entities(entities)
 
@@ -54,17 +87,31 @@ class SurePetModeSwitch(CoordinatorEntity, SwitchEntity):
         """Initialize a Sure Pet care Pet Mode Switch."""
         self.spc = spc
         self.coordinator = spc.coordinator
-        self._surepy_entity: SurePet = entity
+        self._surepy_entity: SurePet = cast(SurePet, entity) # Ensure type for pet methods
 
-        self._pet_id = entity.id
-        self._tag_id = entity.tag_id
-        # Get _device_id from raw_data['position']
+        self._pet_id = self._surepy_entity.id
+        self._tag_id = self._surepy_entity.tag_id
+        
+        # Determine _device_id in __init__ using the same robust logic as async_setup_entry
         self._device_id = self._surepy_entity.raw_data().get('position', {}).get('device_id')
+        if self._device_id is None and self._tag_id is not None:
+            found_flap_id_init = None
+            for device_id, device_entity in spc.coordinator.data.items():
+                if isinstance(device_entity, SurepyDevice) and device_entity.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP]:
+                    device_raw_data = device_entity.raw_data()
+                    if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
+                        for tag_entry in device_raw_data['tags']:
+                            if tag_entry.get('id') == self._tag_id:
+                                found_flap_id_init = device_id
+                                break
+                        if found_flap_id_init:
+                            break
+            self._device_id = found_flap_id_init # Set _device_id to found flap ID, or None if no flap found.
 
         super().__init__(self.coordinator)
 
         self._attr_unique_id = f"{DOMAIN}.{self._surepy_entity.name.lower().replace(' ', '_')}_mode_switch"
-        self._attr_name = "Indoor Only Mode"
+        self._attr_name = f"{self._surepy_entity.name} Mode"
         self._attr_icon = "mdi:paw"
 
         self._attr_device_info = {
@@ -83,12 +130,14 @@ class SurePetModeSwitch(CoordinatorEntity, SwitchEntity):
             _LOGGER.debug(f"is_on: Coordinator data is empty for {self._surepy_entity.name}.")
             return None
 
-        current_pet_data: SurePet = self.coordinator.data.get(self._pet_id)
+        current_pet_data: SurePet = cast(SurePet, self.coordinator.data.get(self._pet_id))
+
         if not current_pet_data:
             _LOGGER.debug(f"is_on: Pet {self._surepy_entity.name} (ID: {self._pet_id}) not found in coordinator data. Cannot determine switch state.")
             return None
 
         _LOGGER.debug(f"is_on: Pet {current_pet_data.name} (ID: {current_pet_data.id}) current raw_data: {current_pet_data.raw_data()}")
+
 
         profile_id = None
         current_pet_tag_id = current_pet_data.tag_id
@@ -97,6 +146,7 @@ class SurePetModeSwitch(CoordinatorEntity, SwitchEntity):
             _LOGGER.debug(f"is_on: Pet {current_pet_data.name} (ID: {current_pet_data.id}) has no 'tag_id' in its current data. Cannot determine switch state.")
             return None
 
+        # This _device_id will now reliably be a flap ID (or None if no flap found)
         controlling_device_data = self.coordinator.data.get(self._device_id)
 
         if controlling_device_data:
@@ -119,19 +169,17 @@ class SurePetModeSwitch(CoordinatorEntity, SwitchEntity):
         _LOGGER.debug(f"is_on: Pet {current_pet_data.name} (ID: {current_pet_data.id}) final calculated profile_id: {profile_id}, returning is_on: {is_indoor_only}")
         return is_indoor_only
 
-    async def _wait_for_profile_change(self, target_profile_id: int, max_wait_time: int = 20, polling_interval: float = 1.0) -> bool:
+    async def _wait_for_profile_change(self, target_profile_id: int, max_wait_time: int = 15, polling_interval: float = 1.0) -> bool:
         """
         Polls the coordinator for the specified target profile ID until it's reflected in the data.
         Returns True if the profile changes within the timeout, False otherwise.
         """
-        start_time = asyncio.get_event_loop().time() # Use asyncio.get_event_loop().time() for reliable time tracking
+        start_time = asyncio.get_event_loop().time()
         _LOGGER.debug(f"Starting wait for profile_id {target_profile_id} for pet {self._surepy_entity.name} on device {self._device_id}")
 
         while True:
-            # Request a refresh of the coordinator data
             await self.coordinator.async_request_refresh()
 
-            # Re-evaluate the current state after refresh, using the same logic as is_on
             current_profile_id = None
             controlling_device_data = self.coordinator.data.get(self._device_id)
 
@@ -141,20 +189,19 @@ class SurePetModeSwitch(CoordinatorEntity, SwitchEntity):
                     for tag_entry in device_raw_data['tags']:
                         if tag_entry.get('id') == self._tag_id and tag_entry.get('profile') is not None:
                             current_profile_id = tag_entry.get('profile')
-                            break # Found the profile for this tag
+                            break
 
             _LOGGER.debug(f"Polling: Current profile for {self._surepy_entity.name} on device {self._device_id}: {current_profile_id}")
 
             if current_profile_id == target_profile_id:
                 _LOGGER.debug(f"Polling: Profile changed to {target_profile_id} for {self._surepy_entity.name} within timeout.")
-                return True # State updated, exit polling
+                return True
 
-            # Check for timeout
             if asyncio.get_event_loop().time() - start_time > max_wait_time:
                 _LOGGER.warning(f"Polling: Profile for {self._surepy_entity.name} did not change to {target_profile_id} within {max_wait_time} seconds.")
-                return False # Timeout, exit polling
+                return False
 
-            await asyncio.sleep(polling_interval) # Wait before next poll
+            await asyncio.sleep(polling_interval)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on (set pet to 'Indoor Only' mode)."""
@@ -165,8 +212,7 @@ class SurePetModeSwitch(CoordinatorEntity, SwitchEntity):
         _LOGGER.debug(f"Turning ON (Indoor Only) for pet {self._surepy_entity.name} (tag_id: {self._tag_id}) on device {self._device_id}")
         await self.spc.set_pet_indoor_mode(device_id=self._device_id, tag_id=self._tag_id)
 
-        # Poll for the state to update to Profile 3 (Indoor Only)
-        if not await self._wait_for_profile_change(target_profile_id=3, max_wait_time=20, polling_interval=1.0):
+        if not await self._wait_for_profile_change(target_profile_id=3, max_wait_time=15, polling_interval=1.0):
             _LOGGER.error(f"Failed to confirm pet {self._surepy_entity.name} is in Indoor Only mode after setting within timeout.")
 
 
@@ -179,6 +225,5 @@ class SurePetModeSwitch(CoordinatorEntity, SwitchEntity):
         _LOGGER.debug(f"Turning OFF (Outdoor) for pet {self._surepy_entity.name} (tag_id: {self._tag_id}) on device {self._device_id}")
         await self.spc.set_pet_outdoor_mode(device_id=self._device_id, tag_id=self._tag_id)
 
-        # Poll for the state to update to Profile 2 (Outdoor)
-        if not await self._wait_for_profile_change(target_profile_id=2, max_wait_time=20, polling_interval=1.0):
+        if not await self._wait_for_profile_change(target_profile_id=2, max_wait_time=15, polling_interval=1.0):
             _LOGGER.error(f"Failed to confirm pet {self._surepy_entity.name} is in Outdoor mode after setting within timeout.")

--- a/custom_components/sureha/switch.py
+++ b/custom_components/sureha/switch.py
@@ -1,0 +1,184 @@
+"""Switch for Sure PetCare Flaps/Pets modes."""
+from __future__ import annotations
+
+import logging
+import asyncio # Keep this import
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+# pylint: disable=relative-beyond-top-level
+from . import DOMAIN, SurePetcareAPI
+from surepy.entities import SurepyEntity
+from surepy.entities.pet import Pet as SurePet
+from surepy.enums import EntityType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up Sure Petcare pet mode switches."""
+    spc: SurePetcareAPI = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+    for _id, entity in spc.coordinator.data.items():
+        if isinstance(entity, SurePet):
+            # Get the tag_id and the associated device_id from raw_data
+            pet_tag_id = entity.tag_id
+            # Get associated_device_id from raw_data['position']
+            associated_device_id = entity.raw_data().get('position', {}).get('device_id')
+
+            if pet_tag_id is not None and associated_device_id is not None:
+                _LOGGER.debug(f"Adding switch for pet {entity.name} (ID: {entity.id}, Tag ID: {pet_tag_id}, Device ID: {associated_device_id})")
+                entities.append(SurePetModeSwitch(spc, entity))
+            else:
+                _LOGGER.debug(f"Skipping switch for pet {entity.name} (ID: {entity.id}): tag_id ({pet_tag_id}) or associated device_id ({associated_device_id}) is missing. This pet may not be linked to a flap or feeder.")
+
+    async_add_entities(entities)
+
+
+class SurePetModeSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch for pet indoor/outdoor mode."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, spc: SurePetcareAPI, entity: SurepyEntity) -> None:
+        """Initialize a Sure Pet care Pet Mode Switch."""
+        self.spc = spc
+        self.coordinator = spc.coordinator
+        self._surepy_entity: SurePet = entity
+
+        self._pet_id = entity.id
+        self._tag_id = entity.tag_id
+        # Get _device_id from raw_data['position']
+        self._device_id = self._surepy_entity.raw_data().get('position', {}).get('device_id')
+
+        super().__init__(self.coordinator)
+
+        self._attr_unique_id = f"{DOMAIN}.{self._surepy_entity.name.lower().replace(' ', '_')}_mode_switch"
+        self._attr_name = "Indoor Only Mode"
+        self._attr_icon = "mdi:paw"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, self._pet_id)},
+            "name": self._surepy_entity.name,
+            "manufacturer": "Sure Petcare",
+            "model": "Pet",
+        }
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if pet is currently in 'Indoor Only' mode (profile_id = 3)."""
+        _LOGGER.debug(f"is_on property called for {self._surepy_entity.name} (ID: {self._pet_id})")
+
+        if not self.coordinator.data:
+            _LOGGER.debug(f"is_on: Coordinator data is empty for {self._surepy_entity.name}.")
+            return None
+
+        current_pet_data: SurePet = self.coordinator.data.get(self._pet_id)
+        if not current_pet_data:
+            _LOGGER.debug(f"is_on: Pet {self._surepy_entity.name} (ID: {self._pet_id}) not found in coordinator data. Cannot determine switch state.")
+            return None
+
+        _LOGGER.debug(f"is_on: Pet {current_pet_data.name} (ID: {current_pet_data.id}) current raw_data: {current_pet_data.raw_data()}")
+
+        profile_id = None
+        current_pet_tag_id = current_pet_data.tag_id
+
+        if not current_pet_tag_id:
+            _LOGGER.debug(f"is_on: Pet {current_pet_data.name} (ID: {current_pet_data.id}) has no 'tag_id' in its current data. Cannot determine switch state.")
+            return None
+
+        controlling_device_data = self.coordinator.data.get(self._device_id)
+
+        if controlling_device_data:
+            _LOGGER.debug(f"is_on: Checking controlling device {controlling_device_data.name} (ID: {controlling_device_data.id}, Type: {controlling_device_data.type}) for tags.")
+            device_raw_data = controlling_device_data.raw_data()
+            if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
+                _LOGGER.debug(f"is_on: Controlling Device {controlling_device_data.name} tags: {device_raw_data['tags']}")
+                for tag_entry in device_raw_data['tags']:
+                    if tag_entry.get('id') == current_pet_tag_id and tag_entry.get('profile') is not None:
+                        profile_id = tag_entry.get('profile')
+                        _LOGGER.debug(f"is_on: Found matching tag (ID: {current_pet_tag_id}) on controlling device {controlling_device_data.name} with profile_id: {profile_id}")
+                        break
+            else:
+                 _LOGGER.debug(f"is_on: Controlling Device {controlling_device_data.name} has no 'tags' or invalid 'tags' data.")
+        else:
+            _LOGGER.warning(f"is_on: Controlling device (ID: {self._device_id}) not found in coordinator data for pet {self._surepy_entity.name}. Cannot determine state.")
+
+
+        is_indoor_only = profile_id == 3 if profile_id is not None else None
+        _LOGGER.debug(f"is_on: Pet {current_pet_data.name} (ID: {current_pet_data.id}) final calculated profile_id: {profile_id}, returning is_on: {is_indoor_only}")
+        return is_indoor_only
+
+    async def _wait_for_profile_change(self, target_profile_id: int, max_wait_time: int = 20, polling_interval: float = 1.0) -> bool:
+        """
+        Polls the coordinator for the specified target profile ID until it's reflected in the data.
+        Returns True if the profile changes within the timeout, False otherwise.
+        """
+        start_time = asyncio.get_event_loop().time() # Use asyncio.get_event_loop().time() for reliable time tracking
+        _LOGGER.debug(f"Starting wait for profile_id {target_profile_id} for pet {self._surepy_entity.name} on device {self._device_id}")
+
+        while True:
+            # Request a refresh of the coordinator data
+            await self.coordinator.async_request_refresh()
+
+            # Re-evaluate the current state after refresh, using the same logic as is_on
+            current_profile_id = None
+            controlling_device_data = self.coordinator.data.get(self._device_id)
+
+            if controlling_device_data:
+                device_raw_data = controlling_device_data.raw_data()
+                if 'tags' in device_raw_data and isinstance(device_raw_data['tags'], list):
+                    for tag_entry in device_raw_data['tags']:
+                        if tag_entry.get('id') == self._tag_id and tag_entry.get('profile') is not None:
+                            current_profile_id = tag_entry.get('profile')
+                            break # Found the profile for this tag
+
+            _LOGGER.debug(f"Polling: Current profile for {self._surepy_entity.name} on device {self._device_id}: {current_profile_id}")
+
+            if current_profile_id == target_profile_id:
+                _LOGGER.debug(f"Polling: Profile changed to {target_profile_id} for {self._surepy_entity.name} within timeout.")
+                return True # State updated, exit polling
+
+            # Check for timeout
+            if asyncio.get_event_loop().time() - start_time > max_wait_time:
+                _LOGGER.warning(f"Polling: Profile for {self._surepy_entity.name} did not change to {target_profile_id} within {max_wait_time} seconds.")
+                return False # Timeout, exit polling
+
+            await asyncio.sleep(polling_interval) # Wait before next poll
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on (set pet to 'Indoor Only' mode)."""
+        if self._tag_id is None or self._device_id is None:
+            _LOGGER.error(f"Failed to turn on indoor mode for {self._surepy_entity.name}: Missing tag_id ({self._tag_id}) or device_id ({self._device_id}).")
+            return
+
+        _LOGGER.debug(f"Turning ON (Indoor Only) for pet {self._surepy_entity.name} (tag_id: {self._tag_id}) on device {self._device_id}")
+        await self.spc.set_pet_indoor_mode(device_id=self._device_id, tag_id=self._tag_id)
+
+        # Poll for the state to update to Profile 3 (Indoor Only)
+        if not await self._wait_for_profile_change(target_profile_id=3, max_wait_time=20, polling_interval=1.0):
+            _LOGGER.error(f"Failed to confirm pet {self._surepy_entity.name} is in Indoor Only mode after setting within timeout.")
+
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off (set pet to 'Outdoor' mode)."""
+        if self._tag_id is None or self._device_id is None:
+            _LOGGER.error(f"Failed to turn off outdoor mode for {self._surepy_entity.name}: Missing tag_id ({self._tag_id}) or device_id ({self._device_id}).")
+            return
+
+        _LOGGER.debug(f"Turning OFF (Outdoor) for pet {self._surepy_entity.name} (tag_id: {self._tag_id}) on device {self._device_id}")
+        await self.spc.set_pet_outdoor_mode(device_id=self._device_id, tag_id=self._tag_id)
+
+        # Poll for the state to update to Profile 2 (Outdoor)
+        if not await self._wait_for_profile_change(target_profile_id=2, max_wait_time=20, polling_interval=1.0):
+            _LOGGER.error(f"Failed to confirm pet {self._surepy_entity.name} is in Outdoor mode after setting within timeout.")


### PR DESCRIPTION
I have added 2 new "modes" to pets, this allows them to be set as "indoor only" or "outdoor". I have also added this information to the pet attributes and created 2 services to call these methods. A new switch has been created to easily toggle the mode per pet. Finally I have attempted to fix the issue of the feeders constantly duplicating each time HA restarts, this looked to be due to unique IDs. 

Please note this requires the surepy PR here: https://github.com/benleb/surepy/pull/223